### PR TITLE
Feature/ssh agent auth

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.23.2
         id: go
       -
         name: Run GoReleaser

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ With this Wireshark Extcap plugin, you can capture traffic from FortiGate firewa
 ## Features
 
 - Capture & Stream packets directly from the Fortigate into Wireshark
-- SSH password or SSH key authentication
+- SSH agent authentication (no credentials on the command line)
+- SSH password authentication
 - Run multiple live capture sessions simultaneously
 - Fortigate VDOM Support
 - Easy installation
@@ -46,8 +47,11 @@ Click the gear icon to configure the following parameters:
 
 **Authentication Tab:**
 - **Username:** SSH Username (e.g. `admin`). This user must have CLI access permissions on the FortiGate.
-- **Password:** The user's password. Also used as the passphrase if an encrypted SSH private key is provided.
-- **Path to SSH Private Key:** Optional. Path to a local SSH private key file for key-based authentication. If provided, key authentication is attempted first, with password as fallback.
+- **Password:** The user's SSH password. Leave empty when using SSH agent authentication.
+
+The plugin supports two authentication methods, tried in this order:
+1. **SSH agent** — if an SSH agent is running with a key loaded for the FortiGate, no password is needed. This is the recommended approach as it keeps credentials off the command line.
+2. **Password** — enter the password in the field above.
 
 **Debug Tab:**
 - **Multi-VDOM check:** Enable if the FortiGate is running in multi-VDOM mode. When enabled, the plugin automatically enters the management VDOM before starting the capture.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ mkdir -p $HOME/.local/lib/wireshark/extcap
 cp fortigate-extcap $HOME/.local/lib/wireshark/extcap/fortigate-extcap
 ```
 
+## Documentation
+
+For full configuration details, authentication setup, and troubleshooting, see the [Help Documentation](docs/index.md).
+
 ## Known limitations
 - Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, which streams packets as a text hexdump over SSH rather than a binary protocol. Use a specific capture filter to focus on the traffic you need and avoid overloading the stream.
 - This Extcap plugin is still under development. Currently it's in an early beta stage.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,36 @@ This plugin lets you capture packets directly from a FortiGate firewall into Wir
 | Field | Description |
 |---|---|
 | **Username** | SSH username (e.g. `admin`). Must have CLI access on the FortiGate. |
-| **Password** | SSH password, or passphrase for an encrypted private key. |
-| **Path to SSH Private Key** | Optional. Path to a local SSH private key file. Key auth is tried first, password is used as fallback. |
+| **Password** | SSH password. Leave empty when using SSH agent authentication. |
+
+The plugin supports two authentication methods, tried in this order:
+
+1. **SSH agent** — if an SSH agent is running with a key loaded for the FortiGate, no password is needed. This is the recommended approach as no credentials appear on the command line.
+2. **Password** — plain SSH password entered in the field above.
+
+**Setting up SSH agent (Linux/macOS):**
+```bash
+ssh-add ~/.ssh/id_rsa   # type your passphrase once
+```
+Then leave the Password field empty in Wireshark.
+
+**Setting up SSH agent (Windows):**
+```powershell
+# Run once as administrator
+Set-Service ssh-agent -StartupType Automatic
+Start-Service ssh-agent
+# Then add your key
+ssh-add C:\Users\you\.ssh\id_rsa
+```
+
+For SSH agent to work, the FortiGate user must have the corresponding public key configured:
+```
+config system admin
+    edit admin
+        set ssh-public-key1 "ssh-rsa AAAA..."
+    next
+end
+```
 
 ### Debug Tab
 
@@ -50,7 +78,8 @@ This plugin lets you capture packets directly from a FortiGate firewall into Wir
 
 **Authentication failed**
 - Verify the username has CLI access on the FortiGate (not just web UI access).
-- If using a private key, confirm the public key is added to the FortiGate user's authorized keys.
+- If using SSH agent, confirm the agent is running (`ssh-add -l`) and the FortiGate user has the public key configured.
+- If using password, verify the password is correct.
 
 **Host key mismatch error**
 - The FortiGate's SSH host key has changed. Remove the old entry with: `ssh-keygen -R <fortigate-address>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,10 @@ The plugin supports two authentication methods, tried in this order:
 
 **Setting up SSH agent (Linux/macOS):**
 ```bash
-ssh-add ~/.ssh/id_rsa   # type your passphrase once
+# Optional: generate a new key pair if you don't have one yet
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
+# Add your key to the agent — type your passphrase once
+ssh-add ~/.ssh/id_ed25519
 ```
 Then leave the Password field empty in Wireshark.
 
@@ -39,11 +42,13 @@ Then leave the Password field empty in Wireshark.
 # Run once as administrator
 Set-Service ssh-agent -StartupType Automatic
 Start-Service ssh-agent
-# Then add your key
-ssh-add C:\Users\you\.ssh\id_rsa
+# Optional: generate a new key pair if you don't have one yet
+ssh-keygen -t ed25519 -f C:\Users\you\.ssh\id_ed25519
+# Add your key to the agent
+ssh-add C:\Users\you\.ssh\id_ed25519
 ```
 
-For SSH agent to work, the FortiGate user must have the corresponding public key configured:
+For SSH agent to work, the FortiGate user must have the corresponding public key configured. The public key is the `.pub` file generated alongside your private key (e.g. `~/.ssh/id_ed25519.pub` on Linux/macOS or `C:\Users\you\.ssh\id_ed25519.pub` on Windows). Copy its contents into the FortiGate config:
 ```
 config system admin
     edit admin
@@ -51,6 +56,8 @@ config system admin
     next
 end
 ```
+
+> **Note:** FortiGate requires a password to be set on every admin account, even when using SSH key authentication. Since this password will never be used for day-to-day access, set it to a long randomly generated string (32+ characters). Store it in a password manager.
 
 ### Debug Tab
 
@@ -72,7 +79,7 @@ end
 
 ## Troubleshooting
 
-**Wireshark shows no interface after installing**
+**Wireshark shows no Fortigate extcap Plugin after installing**
 - Make sure the binary is placed in the correct extcap folder: *Help → About Wireshark → Folders → Personal Extcap Path*
 - On Linux/macOS, make sure the binary is executable: `chmod +x fortigate-extcap`
 

--- a/fortidump.go
+++ b/fortidump.go
@@ -618,6 +618,21 @@ func newSSHSession(username *string, password *string, hostname *string, port *i
 	client, err := ssh.Dial("tcp", *hostname+":"+strconv.Itoa(*port), config)
 	if err != nil {
 		debuglog(logLevelError, "Dial error: %s", err)
+		if strings.Contains(err.Error(), "unable to authenticate") {
+			return nil, fmt.Errorf("authentication failed: incorrect password or SSH agent has no valid key for this host")
+		}
+		if strings.Contains(err.Error(), "Too many authentication failures") {
+			return nil, fmt.Errorf("authentication failed: too many failed attempts, the host may have blocked further logins")
+		}
+		if strings.Contains(err.Error(), "i/o timeout") {
+			return nil, fmt.Errorf("connection timed out: verify the FortiGate address and SSH port are correct and reachable")
+		}
+		if strings.Contains(err.Error(), "no route to host") {
+			return nil, fmt.Errorf("no route to host: verify the FortiGate address is correct and the host is reachable")
+		}
+		if strings.Contains(err.Error(), "EOF") {
+			return nil, fmt.Errorf("connection closed unexpectedly: the FortiGate terminated the connection during handshake — a common cause is a trusted host restriction on the admin account")
+		}
 		return nil, fmt.Errorf("authentication failed: %w", err)
 	}
 

--- a/fortidump.go
+++ b/fortidump.go
@@ -319,8 +319,7 @@ func extcapConfig() {
 
 	// Authentication Tab
 	fmt.Println("arg {number=4}{call=--username}{display=Username}{type=string}{tooltip=The remote SSH username. If not provided, the current user will be used}{required=true}{group=Authentication}")
-	fmt.Println("arg {number=5}{call=--password}{display=Password}{type=password}{tooltip=The SSH password, used when other methods (SSH agent or key files) are unavailable.}{group=Authentication}")
-	fmt.Println("arg {number=6}{call=--sshkey}{display=Path to SSH Private Key}{type=fileselect}{tooltip=The path on the local filesystem of the private ssh key}{group=Authentication}")
+	fmt.Println("arg {number=5}{call=--password}{display=Password}{type=password}{tooltip=The SSH password. Leave empty when using SSH agent authentication.}{group=Authentication}")
 
 	// Debug Tab
 	fmt.Println("arg {number=7}{call=--log-level}{display=Set the log level}{type=selector}{tooltip=The remote SSH username. If not provided, the current user will be used}{required=false}{group=Debug}")
@@ -400,7 +399,6 @@ func main() {
 	extcapPort := flag.Int("port", 22, "The remote SSH port")
 	extcapUsername := flag.String("username", "", "The remote SSH Username")
 	extcapPassword := flag.String("password", "", "The remote SSH Password")
-	extcapSshKey := flag.String("sshkey", "", "Path of ssh key used for passwordless authentication")
 	extcapCaptureFilter := flag.String("capture-filter", "none", "Diagnose sniffer packet capture filter")
 	extcapCaptureInterface := flag.String("capture-interface", "any", "Capture interface on Fortigate")
 	extcapLogLevel := flag.Int("log-level", logLevelError, "Loglevel Debug(0) - Error(3) / Default 3")
@@ -511,18 +509,13 @@ func main() {
 			debuglog(logLevelError, "Fatal: No SSH username defined")
 			os.Exit(errorArg)
 		}
-		if *extcapPassword == "" && *extcapSshKey == "" {
-			fmt.Fprintln(os.Stderr, "No SSH password or SSH Key defined")
-			debuglog(logLevelError, "Fatal: No SSH password or SSH Key defined")
-			os.Exit(errorArg)
-		}
 		if *extcapFifo == "" {
 			fmt.Fprintln(os.Stderr, "No fifo file defined")
 			debuglog(logLevelError, "Fatal: No fifo file defined")
 			os.Exit(errorFifo)
 		}
 
-		err := startCaptureSession(extcapFifo, extcapUsername, extcapPassword, extcapSshKey, extcapHost, extcapPort, extcapCaptureInterface, extcapCaptureFilter, extcapPacketLimit)
+		err := startCaptureSession(extcapFifo, extcapUsername, extcapPassword, extcapHost, extcapPort, extcapCaptureInterface, extcapCaptureFilter, extcapPacketLimit)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			debuglog(logLevelError, "Fatal: %s", err)
@@ -564,7 +557,7 @@ func addHostKey(host string, remote net.Addr, pubKey ssh.PublicKey) error {
 	return fileErr
 }
 
-func newSSHSession(username *string, signer *ssh.Signer, password *string, hostname *string, port *int) (*sshShell, error) {
+func newSSHSession(username *string, password *string, hostname *string, port *int) (*sshShell, error) {
 
 	var (
 		keyErr *knownhosts.KeyError
@@ -574,16 +567,22 @@ func newSSHSession(username *string, signer *ssh.Signer, password *string, hostn
 
 	sshShellSession := sshShell{}
 
-	authmethod := []ssh.AuthMethod{
-		ssh.Password(*password),
+	authmethod := []ssh.AuthMethod{}
+
+	if agentClient, cleanup, err := getAgentAuthSigners(); err != nil {
+		debuglog(logLevelInfo, "SSH agent not available: %s", err)
+	} else {
+		debuglog(logLevelInfo, "SSH agent available, adding as auth method")
+		authmethod = append(authmethod, ssh.PublicKeysCallback(agentClient.Signers))
+		defer cleanup()
 	}
 
-	if *signer != nil {
-		debuglog(logLevelDebug, "signer is not nil: %v", signer)
-		authmethod = []ssh.AuthMethod{
-			ssh.PublicKeys(*signer),
-			ssh.Password(*password),
-		}
+	if *password != "" {
+		authmethod = append(authmethod, ssh.Password(*password))
+	}
+
+	if len(authmethod) == 0 {
+		return nil, fmt.Errorf("no authentication method available: provide a password or configure an SSH agent")
 	}
 
 	config := &ssh.ClientConfig{
@@ -842,7 +841,7 @@ func runSnifferCommand(sshShellSession *sshShell, cmd string, pcapfile *os.File,
 	return scanErr
 }
 
-func startCaptureSession(filename *string, username *string, password *string, keyfile *string, hostname *string, port *int, captureInterface *string, captureFilter *string, packetlimit *int) error {
+func startCaptureSession(filename *string, username *string, password *string, hostname *string, port *int, captureInterface *string, captureFilter *string, packetlimit *int) error {
 
 	debuglog(logLevelInfo, "startCaptureSession starting")
 	defer debuglog(logLevelInfo, "startCaptureSession exiting")
@@ -856,31 +855,8 @@ func startCaptureSession(filename *string, username *string, password *string, k
 
 	defer pcapFile.Close()
 
-	var signer ssh.Signer
-
-	key, err := os.ReadFile(*keyfile)
-	if err != nil {
-		debuglog(logLevelError, "Unable to read keyfile: %s", err)
-	} else {
-		signer, err = ssh.ParsePrivateKey(key)
-		if err != nil {
-			if _, ok := err.(*ssh.PassphraseMissingError); ok {
-				signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(*password))
-				if err != nil {
-					debuglog(logLevelError, "Failed to parse private key with passphrase: %v", err)
-					fmt.Fprintln(os.Stderr, "Failed to parse private key with passphrase")
-					return err
-				}
-			} else {
-				debuglog(logLevelError, "Failed to parse private key, invalid openssh key format: %v", err)
-				fmt.Fprintln(os.Stderr, "Failed to parse private key, invalid openssh key format")
-				return err
-			}
-		}
-	}
-
 	debuglog(logLevelInfo, "connecting SSH to %s:%d", *hostname, *port)
-	sshSession, err := newSSHSession(username, &signer, password, hostname, port)
+	sshSession, err := newSSHSession(username, password, hostname, port)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
-module fortidump.go
+module fortidump
 
 go 1.23.2
 
 require golang.org/x/crypto v0.29.0
 
-require golang.org/x/sys v0.27.0 // indirect
+require golang.org/x/sys v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ golang.org/x/crypto v0.29.0 h1:L5SG1JTTXupVV3n6sUqMTeWbjAyfPwoda2DLX8J8FrQ=
 golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.26.0 h1:WEQa6V3Gja/BhNxg540hBip/kkaYtRg3cxg4oXSw4AU=
+golang.org/x/term v0.26.0/go.mod h1:Si5m1o57C5nBNQo5z1iq+XDijt21BDBDp2bK0QI8e3E=

--- a/ssh_agent_unix.go
+++ b/ssh_agent_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh/agent"
+)
+
+func getAgentAuthSigners() (agent.Agent, func(), error) {
+	socket := os.Getenv("SSH_AUTH_SOCK")
+	if socket == "" {
+		return nil, nil, fmt.Errorf("SSH_AUTH_SOCK not set")
+	}
+	conn, err := net.Dial("unix", socket)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to SSH agent: %w", err)
+	}
+	return agent.NewClient(conn), func() { conn.Close() }, nil
+}

--- a/ssh_agent_windows.go
+++ b/ssh_agent_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/sys/windows"
+)
+
+func getAgentAuthSigners() (agent.Agent, func(), error) {
+	pipePath := `\\.\pipe\openssh-ssh-agent`
+	handle, err := windows.CreateFile(
+		windows.StringToUTF16Ptr(pipePath),
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		0, nil,
+		windows.OPEN_EXISTING,
+		0,
+		0,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to SSH agent pipe: %w", err)
+	}
+	f := os.NewFile(uintptr(handle), pipePath)
+	return agent.NewClient(f), func() { f.Close() }, nil
+}


### PR DESCRIPTION
  Replaces the SSH private key file option with SSH agent support, removing credentials from the Wireshark command line.

  Changes

  Authentication
  - Added SSH agent authentication (Linux/macOS via $SSH_AUTH_SOCK, Windows via \\.\pipe\openssh-ssh-agent)
  - Removed --sshkey flag and key file reading logic
  - Auth priority: SSH agent first, password fallback
  - Password field is now optional when an agent is configured

  Error messages
  - Replaced cryptic SSH handshake errors with readable messages for: wrong password, too many auth failures, connection timeout, no route
   to host, and EOF (trusted host restriction)

  Build & CI
  - Fixed module name in go.mod (fortidump.go → fortidump) — previously caused go build without -o to overwrite the source file
  - Bumped Go version in CI workflow from 1.21.3 to 1.23.2 to match go.mod

  Documentation
  - Updated README and docs/index.md with SSH agent setup instructions for Linux/macOS and Windows
  - Added FortiGate public key configuration example
  - Added recommendation to set a long random password on the FortiGate admin account when using key-based auth

  Testing

  - SSH agent auth (no password): working
  - Password auth (no agent): working
  - No credentials provided: correct error message shown
  - Error messages validated for wrong password, too many failures, timeout, no route to host, EOF