### PR TITLE
PCAPng output, auto VDOM detection, auto SSH exclusion (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ For full configuration details, authentication setup, and troubleshooting, see t
 
 ## Known limitations
 - Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, which streams packets as a text hexdump over SSH rather than a binary protocol. Use a specific capture filter to focus on the traffic you need and avoid overloading the stream.
-- This Extcap plugin is still under development. Currently it's in an early beta stage.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Click the gear icon to configure the following parameters:
 **Server Tab**
 - **Fortigate Address:** IP or hostname of the target Firewall.
 - **Fortigate SSH Port:** The SSH port used to connect.
-- **Capture Filter:** Capture filter in tcpdump format. Adjust this to match the traffic you're interested in.
+- **Capture Filter:** Capture filter in tcpdump format (e.g. `not port 443`). Leave empty to capture all traffic. The SSH management session is excluded automatically.
 - **Interface:** The Fortigate interface where the capture will run.
 - **Packet count:** The maximum number of packets to capture.
 
@@ -55,6 +55,8 @@ The plugin supports two authentication methods, tried in this order:
 2. **Password** — enter the password in the field above.
 
 **Debug Tab:**
+- **Log level:** Verbosity of the log output. `Error` is the default. Set to `Debug` when troubleshooting.
+- **Log file:** Path to write log output to. No output is written unless a file is specified.
 - **Known Hostsfile:** Path to the SSH known_hosts file. Defaults to `~/.ssh/known_hosts`. The FortiGate's host key is automatically added on first connection.
 
 Once everything is configured, start the capture by double-clicking the interface.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,6 @@
 
 This plugin lets you capture packets directly from a FortiGate firewall into Wireshark over SSH.
 
----
-
 ## Configuration
 
 ### Server Tab
@@ -71,14 +69,10 @@ end
 | **Log file** | Path to write log output to. No output is written unless a file is specified. |
 | **Known Hostsfile** | Path to the SSH known_hosts file (default: `~/.ssh/known_hosts`). The FortiGate's host key is added automatically on first connection. |
 
----
-
 ## Known Limitations
 
 - Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, which streams packets as a text hexdump over SSH rather than a binary protocol. Use a specific capture filter to focus on the traffic you need and avoid overloading the stream.
 - The FortiGate host key is added to known_hosts automatically on first connection. No manual action is needed.
-
----
 
 ## Troubleshooting
 
@@ -107,8 +101,6 @@ config firewall policy
 end
 ```
 Remember to re-enable it after capturing.
-
----
 
 ## More Information
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ This plugin lets you capture packets directly from a FortiGate firewall into Wir
 |---|---|
 | **FortiGate Address** | IP address or hostname of the FortiGate |
 | **FortiGate SSH Port** | SSH port (default: 22) |
-| **Capture Filter** | Traffic filter in tcpdump syntax (e.g. `not port 22`). Use a specific filter to focus on the traffic you need. |
+| **Capture Filter** | Traffic filter in tcpdump syntax (e.g. `not port 443`). Leave empty to capture all traffic. The SSH management session is excluded automatically. |
 | **Interface** | FortiGate interface to capture on (e.g. `port1`, `any`). When set to `any`, each packet in Wireshark shows which interface it arrived on. |
 | **Packet count** | Maximum number of packets to capture. Set to `0` for unlimited. |
 
@@ -76,7 +76,7 @@ end
 ## Known Limitations
 
 - Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, which streams packets as a text hexdump over SSH rather than a binary protocol. Use a specific capture filter to focus on the traffic you need and avoid overloading the stream.
-- Wireshark may show a warning on first connection while the host key is being added to known_hosts — this is expected.
+- The FortiGate host key is added to known_hosts automatically on first connection. No manual action is needed.
 
 ---
 
@@ -95,7 +95,18 @@ end
 - The FortiGate's SSH host key has changed. Remove the old entry with: `ssh-keygen -R <fortigate-address>`
 
 **Capture starts but no packets appear**
-- Your capture filter may be too restrictive, or the interface name is wrong. Try `any` as the interface and `not port 22` as the filter.
+- Your capture filter may be too restrictive, or the interface name is wrong. Try `any` as the interface and leave the capture filter empty.
+
+**Packets missing from capture**
+- FortiGate's NP offloading accelerates traffic through dedicated hardware processors, bypassing the software sniffer. To capture this traffic, temporarily disable NP offloading on the relevant firewall policy:
+```
+config firewall policy
+    edit <id>
+        set auto-asic-offload disable
+    next
+end
+```
+Remember to re-enable it after capturing.
 
 ---
 

--- a/fortidump.go
+++ b/fortidump.go
@@ -357,24 +357,24 @@ func extractSinglePacket(inputData *string) (*networkPacket, error) {
 func extcapConfig() {
 
 	// Server Tab
-	fmt.Println("arg {number=0}{call=--host}{display=Fortigate Address}{type=string}{tooltip=The remote Fortigate. It can be both an IP address or a hostname}{required=true}{group=Server}")
-	fmt.Println("arg {number=1}{call=--port}{display=Fortigate SSH Port}{type=unsigned}{tooltip=The remote SSH host port (1-65535)}{range=1,65535}{default=22}{required=true}{group=Server}")
-	fmt.Println("arg {number=2}{call=--capture-filter}{display=Capture filter}{type=string}{tooltip=tcpdump filter}{default=not port 22}{required=true}{group=Server}")
-	fmt.Println("arg {number=3}{call=--capture-interface}{display=Interface}{type=string}{tooltip=filter by interface}{default=any}{required=true}{group=Server}")
-	fmt.Println("arg {number=10}{call=--packetlimit}{display=Packet count}{type=unsigned}{tooltip=Limit the maximum packet count. 0=unlimited}{default=1000}{required=true}{group=Server}")
+	fmt.Println("arg {number=0}{call=--host}{display=Fortigate Address}{type=string}{tooltip=IP address or hostname of the FortiGate firewall}{required=true}{group=Server}")
+	fmt.Println("arg {number=1}{call=--port}{display=Fortigate SSH Port}{type=unsigned}{tooltip=SSH port used to connect to the FortiGate (default: 22)}{range=1,65535}{default=22}{required=true}{group=Server}")
+	fmt.Println("arg {number=2}{call=--capture-filter}{display=Capture Filter}{type=string}{tooltip=Capture filter in tcpdump syntax. Leave empty to capture all traffic. The SSH management session is excluded automatically. Example: not port 443}{required=false}{group=Server}")
+	fmt.Println("arg {number=3}{call=--capture-interface}{display=Interface}{type=string}{tooltip=FortiGate interface to capture on (e.g. port1, any). Use any to capture on all interfaces.}{default=any}{required=true}{group=Server}")
+	fmt.Println("arg {number=10}{call=--packetlimit}{display=Packet count}{type=unsigned}{tooltip=Maximum number of packets to capture. Set to 0 for unlimited.}{default=1000}{required=true}{group=Server}")
 
 	// Authentication Tab
 	fmt.Println("arg {number=4}{call=--username}{display=Username}{type=string}{tooltip=The remote SSH username. If not provided, the current user will be used}{required=true}{group=Authentication}")
 	fmt.Println("arg {number=5}{call=--password}{display=Password}{type=password}{tooltip=The SSH password. Leave empty when using SSH agent authentication.}{group=Authentication}")
 
 	// Debug Tab
-	fmt.Println("arg {number=7}{call=--log-level}{display=Set the log level}{type=selector}{tooltip=The remote SSH username. If not provided, the current user will be used}{required=false}{group=Debug}")
+	fmt.Println("arg {number=7}{call=--log-level}{display=Log level}{type=selector}{tooltip=Verbosity of log output. Use Debug when troubleshooting.}{required=false}{group=Debug}")
 	fmt.Println("value {arg=7}{value=" + strconv.Itoa(logLevelError) + "}{display=Error}")
 	fmt.Println("value {arg=7}{value=" + strconv.Itoa(logLevelWarn) + "}{display=Warning}")
 	fmt.Println("value {arg=7}{value=" + strconv.Itoa(logLevelInfo) + "}{display=Info}")
 	fmt.Println("value {arg=7}{value=" + strconv.Itoa(logLevelDebug) + "}{display=Debug}")
-	fmt.Println("arg {number=8}{call=--log-file}{display=Use a file for logging}{type=fileselect}{tooltip=Set a file where log messages are written}{required=false}{group=Debug}")
-	fmt.Println("arg {number=11}{call=--knownhosts}{display=Known Hostsfile}{type=fileselect}{tooltip=Path to knownhosts file}{required=true}{default=" + sshKnownHostsfile + "}{group=Debug}")
+	fmt.Println("arg {number=8}{call=--log-file}{display=Log file}{type=fileselect}{tooltip=Path to write log output to. No output is written unless a file is specified.}{required=false}{group=Debug}")
+	fmt.Println("arg {number=11}{call=--knownhosts}{display=Known Hostsfile}{type=fileselect}{tooltip=Path to the SSH known_hosts file. The FortiGate host key is added automatically on first connection.}{required=false}{default=" + sshKnownHostsfile + "}{group=Debug}")
 
 }
 
@@ -444,7 +444,7 @@ func main() {
 	extcapPort := flag.Int("port", 22, "The remote SSH port")
 	extcapUsername := flag.String("username", "", "The remote SSH Username")
 	extcapPassword := flag.String("password", "", "The remote SSH Password")
-	extcapCaptureFilter := flag.String("capture-filter", "none", "Diagnose sniffer packet capture filter")
+	extcapCaptureFilter := flag.String("capture-filter", "", "Diagnose sniffer packet capture filter")
 	extcapCaptureInterface := flag.String("capture-interface", "any", "Capture interface on Fortigate")
 	extcapLogLevel := flag.Int("log-level", logLevelError, "Loglevel Debug(0) - Error(3) / Default 3")
 	extcapLogFile := flag.String("log-file", "", "Log filename")
@@ -911,10 +911,40 @@ func runSnifferCommand(sshShellSession *sshShell, cmd string, pcapfile *os.File,
 	return scanErr
 }
 
+// buildEffectiveFilter returns the filter string to pass to the FortiGate sniffer.
+// It automatically prepends an exclusion for the SSH management session so that
+// the client↔FortiGate SSH traffic never appears in the capture. The user-supplied
+// filter (if any) is appended with AND.
+func buildEffectiveFilter(hostname string, port int, userFilter string) string {
+	sshExclude := fmt.Sprintf("not (host %s and port %d)", hostname, port)
+
+	// Try to resolve the local IP used to reach the FortiGate so we can build
+	// a more precise bidirectional exclusion. UDP dial never sends any packets —
+	// it only performs a routing-table lookup.
+	conn, err := net.Dial("udp", fmt.Sprintf("%s:%d", hostname, port))
+	if err == nil {
+		defer conn.Close()
+		localIP := conn.LocalAddr().(*net.UDPAddr).IP.String()
+		sshExclude = fmt.Sprintf("not (host %s and host %s and port %d)", localIP, hostname, port)
+		debuglog(logLevelInfo, "auto SSH exclusion filter: local IP resolved to %s", localIP)
+	} else {
+		debuglog(logLevelWarn, "could not resolve local IP for SSH exclusion (%v), using host-only filter", err)
+	}
+
+	userFilter = strings.TrimSpace(userFilter)
+	if userFilter == "" || userFilter == "none" {
+		return sshExclude
+	}
+	return fmt.Sprintf("%s and (%s)", sshExclude, userFilter)
+}
+
 func startCaptureSession(filename *string, username *string, password *string, hostname *string, port *int, captureInterface *string, captureFilter *string, packetlimit *int) error {
 
 	debuglog(logLevelInfo, "startCaptureSession starting")
 	defer debuglog(logLevelInfo, "startCaptureSession exiting")
+
+	effectiveFilter := buildEffectiveFilter(*hostname, *port, *captureFilter)
+	debuglog(logLevelInfo, "effective capture filter: %s", effectiveFilter)
 
 	debuglog(logLevelInfo, "opening pcapng file: %s", *filename)
 	pcapFile, err := createPcapngFile(*filename)
@@ -936,9 +966,9 @@ func startCaptureSession(filename *string, username *string, password *string, h
 
 	var sniffCommand string
 	if *packetlimit == 0 {
-		sniffCommand = fmt.Sprintf(`diagnose sniffer packet %s '%s' 6`, *captureInterface, *captureFilter)
+		sniffCommand = fmt.Sprintf(`diagnose sniffer packet %s '%s' 6`, *captureInterface, effectiveFilter)
 	} else {
-		sniffCommand = fmt.Sprintf(`diagnose sniffer packet %s '%s' 6 %d`, *captureInterface, *captureFilter, *packetlimit)
+		sniffCommand = fmt.Sprintf(`diagnose sniffer packet %s '%s' 6 %d`, *captureInterface, effectiveFilter, *packetlimit)
 	}
 	debuglog(logLevelInfo, "sniffer command: %s", sniffCommand)
 

--- a/fortidump.go
+++ b/fortidump.go
@@ -1,9 +1,9 @@
 package main
 
 // Wireshark EXTCAP extension for capturing packets on a Fortigate.
-// Tested with FortiOS 7.4.6, FortiOS 7.2.10
+// Tested with FortiOS 7.4.6, FortiOS 7.2.10, FortiOS 7.6.5
 // Author: Sander Zegers
-// Version: 0.0.4
+// Version: 0.5.0
 // License: GNU General Public License v2.0
 
 // TODO: Fortigate pre-login-banner / post-login-banner support


### PR DESCRIPTION
## Summary

- **PCAPng output** — replaces legacy PCAP format; per-packet interface name and traffic direction (inbound/outbound) are now visible in Wireshark
- **Auto multi-VDOM detection** — the plugin detects VDOM mode from `get system status` and enters the correct VDOM context automatically; no manual configuration needed
- **Auto SSH exclusion** — the SSH management session between the capture client and the FortiGate is automatically excluded from the capture using a routing-table lookup to determine the local IP; works on Windows, macOS and Linux
- **Improved GUI** — capture filter field is now empty by default with a descriptive tooltip; all tooltip copy-paste errors fixed
- **Documentation** — updated to reflect new features; added NP offloading troubleshooting entry; removed stale `not port 22` references
- **Version bump to 0.5.0** — dropped early beta disclaimer; added FortiOS 7.6.5 to tested versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)