### PR TITLE
docs: improve help file and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wireshark Extcap extension for Fortigate
+# Wireshark Extcap extension for FortiGate
 
 [![License](https://img.shields.io/badge/license-GPLv2-blue.svg)](LICENSE)
 
@@ -21,23 +21,16 @@ With this Wireshark Extcap plugin, you can capture traffic from FortiGate firewa
   
 ## Installation
 
-1. Download the Latest Version
- - Visit the [Releases](https://github.com/sanderzegers/fortigate-extcap/releases/) page and download the version that matches your platform.
+1. Download the binary for your platform from the [Releases](https://github.com/sanderzegers/fortigate-extcap/releases/) page.
+2. Copy it to your Wireshark extcap folder: open Wireshark, go to **Help → About Wireshark → Folders → Personal Extcap Path**, and click the location to open it.
+3. Linux/macOS only: make the binary executable: `chmod a+x fortigate-extcap`
+4. Restart Wireshark. The plugin appears as **FortiGate Remote Capture** in the capture interface list.
 
-2. Locate the Personal Extcap Folder
- - Open Wireshark.
- - Navigate to Help → About Wireshark → Folders → Personal Extcap Path.
- - Click the Location to open the Extcap folder.
-
-3. Copy the binary to the Extcap folder
- - From the downloaded release, copy the fortigate-extcap.exe (or the appropriate file for your platform) into the "Personal Extcap Path" directory.
-
-4. Restart Wireshark
- - Restart Wireshark to load the custom Extcap extension.
+For more detail, see the [Help Documentation](docs/index.md#installation).
 
 ## Usage
 
-Once installed, the plugin appears in Wireshark's capture options as **Fortigate Remote Capture (SSH): fortidump**. Click the gear icon to enter the FortiGate address, credentials, and capture settings, then double-click the interface to start capturing.
+Once installed, the plugin appears in Wireshark's capture options as **FortiGate Remote Capture (SSH)**. The interface is listed as `fortidump` — this is the plugin's internal identifier. Click the gear icon to enter the FortiGate address, credentials, and capture settings, then double-click the interface to start capturing.
 
 For detailed configuration, authentication setup, and troubleshooting, see the [Help Documentation](docs/index.md).
 
@@ -46,7 +39,7 @@ For detailed configuration, authentication setup, and troubleshooting, see the [
 To build the binary on your local machine, make sure Go and Git are installed. 
 You can find the plugin folder location in the installation instructions.
 
-Prerequisites: go and git
+Prerequisites: go and git (example for Debian-based systems):
 ```bash
 apt install git golang-go
 ```

--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ cp fortigate-extcap $HOME/.local/lib/wireshark/extcap/fortigate-extcap
 
 - Capture speed is limited by the FortiGate's text-based hexdump output over SSH. See [Help Documentation](docs/index.md#known-limitations) for details.
 
-## Windows Defender false positive
-The Windows binary may be flagged by Microsoft Defender (`Trojan:Win32/Wacatac.B!ml`). This is a known false positive affecting Go binaries that use SSH and cryptography libraries. The source code is fully open and available in this repository.
-
-To resolve this, add an exclusion in Windows Defender for the extcap folder.
-
 ## License
 
 This project is licensed under the [GNU General Public License v2.0](LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,34 @@
 
 This plugin lets you capture packets directly from a FortiGate firewall into Wireshark over SSH.
 
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Installation](#installation)
+- [Starting First Capture](#starting-first-capture)
+- [Configuration](#configuration)
+- [Capture Filter Examples](#capture-filter-examples)
+- [Security Recommendations](#security-recommendations)
+- [Known Limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+- [How It Works](#how-it-works)
+- [More Information](#more-information)
+
+---
+
+## Quick Start
+
+Already have Wireshark installed? Here's the short version:
+
+1. Download the binary for your platform from the [Releases](https://github.com/sanderzegers/fortigate-extcap/releases/) page.
+2. Copy it to your Wireshark extcap folder: open Wireshark, go to **Help → About Wireshark → Folders → Personal Extcap Path**, and click the location to open it.
+3. Linux/macOS only: make the binary executable: `chmod a+x fortigate-extcap`
+4. Restart Wireshark. The plugin appears as **Fortigate Remote Capture** in the capture interface list.
+
+For first-time setup or more detail, see [Installation](#installation) below.
+
+---
+
 ## Installation
 
 1. Download the Latest Version
@@ -22,21 +50,23 @@ This plugin lets you capture packets directly from a FortiGate firewall into Wir
 
 3. Copy the binary to the extcap folder.
 
-- Copy `fortigate-extcap.exe` (or the appropriate file for your platform) from the downloaded release into the “Personal Extcap Path” directory.
+- Copy `fortigate-extcap.exe` (or the appropriate file for your platform) from the downloaded release into the "Personal Extcap Path" directory.
 
-- On Linux or macOS, make the plugin executable: `chmod a+x fortidump`
-
-  
+- On Linux or macOS, make the plugin executable: `chmod a+x fortigate-extcap`
 
 4. Restart Wireshark
 
 - Restart Wireshark to load the custom Extcap extension.
 
-## Starting first capture
+---
 
-After succseful installation, the extcap plugin should become visible as Fortigate Remote Capture. Click on the gear icon to configure the settings.
+## Starting First Capture
+
+After successful installation, the extcap plugin should become visible as Fortigate Remote Capture. Click on the gear icon to configure the settings.
 
 ![wireshark capture options](../images/wireshark_capture_options.png)
+
+---
 
 ## Configuration
 
@@ -54,7 +84,7 @@ After succseful installation, the extcap plugin should become visible as Fortiga
 
 
 
-**Capture Interface:** Wireshark displays the FortiGate interface name for each packet (shown in the frame details under *Interface name*). It also records whether the traffic is inbound or outbound relative to the FortiGate. 
+**Capture Interface:** Wireshark displays the FortiGate interface name for each packet (shown in the frame details under *Interface name*). It also records whether the traffic is inbound or outbound relative to the FortiGate.
 
 ![wireshark capture details](../images/capture_packet_interface.png)
 
@@ -113,6 +143,20 @@ end
 **Note:** FortiGate requires a password to be set on every admin account, even when using SSH key authentication. Since this password will never be used for day-to-day access, set it to a long randomly generated string (32+ characters) and store it in a password manager.
 
 
+**SSH Host Key Verification**
+
+The plugin verifies the FortiGate's SSH host key on every connection using the known_hosts file (default: `~/.ssh/known_hosts`).
+
+- **First connection**: the FortiGate's host key is stored automatically.
+- **Subsequent connections**: the stored key is verified. If it doesn't match, the connection is refused. Common reasons: the FortiGate was replaced, re-imaged, or an HA cluster failed over to a unit with a different host key.
+
+To remove the old entry and allow a fresh key to be stored, either:
+- Run: `ssh-keygen -R <fortigate-address>`
+- Or open `~/.ssh/known_hosts` in a text editor and delete the line that starts with the FortiGate's address or IP.
+
+After removal, the new key is stored automatically on the next connection.
+
+
 
 ### Debug Tab
 
@@ -124,7 +168,60 @@ end
 | **Log file** | Path to write log output to. No output is written unless a file is specified. |
 | **Known Hostsfile** | Path to the SSH known_hosts file (default: `~/.ssh/known_hosts`). The FortiGate host key is added automatically on first connection. |
 
+---
 
+## Capture Filter Examples
+
+Filters use tcpdump syntax and are applied by the FortiGate itself before any data is sent over SSH — so a focused filter also reduces the load on the SSH stream.
+
+| Goal | Filter |
+|---|---|
+| Traffic to/from one host | `host 192.168.1.100` |
+| Traffic within a subnet | `net 10.10.0.0/24` |
+| Web traffic only | `port 80 or port 443` |
+| DNS traffic | `port 53` |
+| ICMP / ping | `icmp` |
+| Exclude a host | `not host 10.0.0.5` |
+| TCP to a specific host and port | `host 10.0.0.1 and tcp port 443` |
+| Filter by MAC address | `ether host 00:50:56:ab:12:34` |
+| LLDP traffic | `ether proto 0x88cc` |
+| Combine: web traffic, one subnet | `net 10.10.0.0/24 and (port 80 or port 443)` |
+
+The SSH management session is always excluded automatically — no need to filter it manually.
+
+---
+
+## Security Recommendations
+
+**Use SSH key authentication**
+
+Passwords are visible in the process list for the entire duration of the capture. SSH agent authentication avoids this entirely. See the [Authentication Tab](#authentication-tab) for setup steps.
+
+**Use a dedicated read-only admin account**
+
+Create a separate FortiGate admin account with only the access needed for packet capture, rather than using the `admin` account. This limits exposure if credentials are ever compromised.
+
+```
+config system accprofile
+    edit "capture-only"
+        set sysgrp read
+        set netgrp read
+        set diaggrp read-write
+    next
+end
+config system admin
+    edit "wireshark"
+        set accprofile "capture-only"
+        set ssh-public-key1 "ssh-ed25519 AAAA..."
+    next
+end
+```
+
+**Verify the host key on first use**
+
+The plugin stores the FortiGate's SSH host key automatically on first connection. Before relying on this, verify the fingerprint manually: run `ssh <fortigate-address>` from a terminal and compare the displayed fingerprint against the value shown in the FortiGate web UI under System → Settings, or via CLI with `get system ssh status`.
+
+---
 
 ## Known Limitations
 
@@ -144,7 +241,7 @@ end
 - If using password, verify the password is correct.
 
 **Host key mismatch error**
-- The FortiGate's SSH host key has changed. Remove the old entry with: `ssh-keygen -R <fortigate-address>`
+- The FortiGate's SSH host key has changed. This can happen after a replacement, re-image, or HA failover to a unit with a different host key. Remove the old entry with: `ssh-keygen -R <fortigate-address>`
 
 **Capture starts but no packets appear**
 - Your capture filter may be too restrictive, or the interface name is wrong. Try `any` as the interface and leave the capture filter empty.
@@ -158,6 +255,42 @@ config firewall policy
     next
 end
 ```
+
+---
+
+## How It Works
+
+```
+  ┌──────────────────────────────────────────┐
+  │ FortiGate                                │
+  │  diagnose sniffer packet <if> <filter> 6 │
+  │  → streams packets as text hexdump       │
+  └─────────────────────┬────────────────────┘
+                        │ SSH tunnel
+                        ▼
+  ┌──────────────────────────────────────────┐
+  │ fortigate-extcap plugin                  │
+  │  parse hexdump                           │
+  │  extract: bytes, interface, direction    │
+  │  → convert to PCAPng frames              │
+  └─────────────────────┬────────────────────┘
+                        │ PCAPng stream
+                        ▼
+  ┌──────────────────────────────────────────┐
+  │ Wireshark                                │
+  │  live capture display                    │
+  └──────────────────────────────────────────┘
+```
+
+The plugin connects to the FortiGate over SSH and runs `diagnose sniffer packet <interface> '<filter>' 6`. The `6` is a verbosity level that makes the FortiGate output each captured packet as a timestamped text hexdump.
+
+The SSH management session is excluded automatically. The plugin determines its own local and remote IP addresses and prepends a `not (host … and host … and port …)` expression to any filter the user enters, so the capture traffic never includes the SSH connection itself.
+
+The plugin reads the hexdump output in real time, extracts the raw packet bytes along with the interface name and traffic direction (inbound/outbound), and converts each packet into PCAPng format. Wireshark receives this as a standard live capture stream.
+
+Because packets travel as text over SSH, throughput is lower than a native binary capture. On busy interfaces, use a capture filter to focus on the traffic you need.
+
+---
 
 ## More Information
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,10 @@ For first-time setup or more detail, see [Installation](#installation) below.
 
 ## Starting First Capture
 
-After successful installation, the extcap plugin should become visible as **Fortigate Remote Capture** in Wireshark's capture interface list. Click the gear icon next to it to open the capture settings, then double-click the interface to start capturing.
+After successful installation, the extcap plugin should become visible as **Fortigate Remote Capture** in Wireshark's capture interface list.
+
+- **First use:** click the gear icon to open the capture settings, configure the FortiGate address and credentials, then click **Start** to begin capturing without leaving the dialog.
+- **Subsequent use:** double-clicking the interface skips the dialog and starts a capture immediately using the last saved settings.
 
 ![wireshark capture options](../images/wireshark_capture_options.png)
 
@@ -93,7 +96,7 @@ See [Configuration](#configuration) for a description of all available settings.
 | Field | Description |
 |---|---|
 | **Username** | SSH username (e.g. `admin`). Must have CLI access on the FortiGate. |
-| **Password** | SSH password. Leave empty when using SSH agent authentication. When using password authentication, the password is visible in the process list for the entire duration of the capture. Use SSH agent authentication to avoid this. |
+| **Password** | SSH password. Leave empty when using SSH agent authentication. When using password authentication, the password is visible in the process list for the entire duration of the capture. Use SSH agent authentication to avoid this. Passwords are not saved to disk and must be re-entered after Wireshark is closed; SSH agent authentication is not affected by this. |
 
 The plugin supports two authentication methods, tried in this order:
 
@@ -134,14 +137,14 @@ end
 
 ### SSH Host Key Verification
 
-The plugin verifies the FortiGate's SSH host key on every connection using the known_hosts file (default: `~/.ssh/known_hosts`).
+The plugin verifies the FortiGate's SSH host key on every connection using the known_hosts file (default: `~/.ssh/known_hosts` on Linux/macOS, `C:\Users\<username>\.ssh\known_hosts` on Windows).
 
 - **First connection**: the FortiGate's host key is stored automatically.
 - **Subsequent connections**: the stored key is verified. If it doesn't match, the connection is refused. Common reasons: the FortiGate was replaced, re-imaged, or an HA cluster failed over to a unit with a different host key.
 
 To remove the old entry and allow a fresh key to be stored, either:
 - Run: `ssh-keygen -R <fortigate-address>`
-- Or open `~/.ssh/known_hosts` in a text editor and delete the line that starts with the FortiGate's address or IP.
+- Or open the known_hosts file (`~/.ssh/known_hosts` on Linux/macOS, `C:\Users\<username>\.ssh\known_hosts` on Windows) in a text editor and delete the line that starts with the FortiGate's address or IP.
 
 After removal, the new key is stored automatically on the next connection.
 
@@ -153,7 +156,7 @@ After removal, the new key is stored automatically on the next connection.
 |---|---|
 | **Log level** | Verbosity of the log output. `Error` is the default. Set to `Debug` when troubleshooting. |
 | **Log file** | Path to write log output to. No output is written unless a file is specified. |
-| **Known Hostsfile** | Path to the SSH known_hosts file (default: `~/.ssh/known_hosts`). The FortiGate host key is added automatically on first connection. |
+| **Known Hostsfile** | Path to the SSH known_hosts file (default: `~/.ssh/known_hosts` on Linux/macOS, `C:\Users\<username>\.ssh\known_hosts` on Windows). The FortiGate host key is added automatically on first connection. |
 
 ---
 
@@ -212,27 +215,27 @@ Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, w
 
 ## Troubleshooting
 
-**Wireshark shows no FortiGate extcap plugin after installing**
+### Wireshark shows no FortiGate extcap plugin after installing
 
 - Make sure the binary is placed in the correct extcap folder: *Help → About Wireshark → Folders → Personal Extcap Path*
 - On Linux/macOS, make sure the binary is executable: `chmod +x fortigate-extcap`
 
-**Authentication failed**
+### Authentication failed
 
 - Verify the username has CLI access on the FortiGate (not just web UI access).
 - If using SSH agent, confirm the agent is running (`ssh-add -l`) and the FortiGate user has the public key configured.
 - If using password, verify the password is correct.
-- If the error mentions a host key problem, see [Host key mismatch error](#troubleshooting) below.
+- If the error mentions a host key problem, see [Host key mismatch error](#host-key-mismatch-error) below.
 
-**Host key mismatch error**
+### Host key mismatch error
 
 - The FortiGate's SSH host key has changed. This can happen after a replacement, re-image, or HA failover to a unit with a different host key. Remove the old entry with: `ssh-keygen -R <fortigate-address>`
 
-**Capture starts but no packets appear**
+### Capture starts but no packets appear
 
 - Your capture filter may be too restrictive, or the interface name is wrong. Try `any` as the interface and leave the capture filter empty.
 
-**Packets missing from capture**
+### Packets missing from capture
 
 - FortiGate's NP offloading accelerates traffic through dedicated hardware processors, bypassing the software sniffer. To capture this traffic, temporarily disable NP offloading on the relevant firewall policy and re-enable it when done:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,39 +32,37 @@ For first-time setup or more detail, see [Installation](#installation) below.
 
 ## Installation
 
-1. Download the Latest Version
+1. **Download the latest version**
 
-- Visit the [Releases](https://github.com/sanderzegers/fortigate-extcap/releases/) page and download the version that matches your platform.
+   Visit the [Releases](https://github.com/sanderzegers/fortigate-extcap/releases/) page and download the version that matches your platform.
 
-2. Locate the Personal Extcap Folder
+2. **Locate the personal extcap folder**
 
-- Open Wireshark
+   Open Wireshark and navigate to **Help → About Wireshark → Folders → Personal Extcap Path**. Click the location to open the extcap folder.
 
-- Navigate to Help → About Wireshark → Folders → Personal Extcap Path.
+   You can install extcap plugins in either the global or personal extcap path. The global path requires admin permissions but makes the plugin available to all users on the system.
 
-- Click the Location to open the Extcap folder
+   ![wireshark about folders](../images/about_wireshark_folders.png)
 
-  You can install extcap plugins in either the global or personal extcap path. The global path requires admin permissions but makes the plugin available to all users on the system.
+3. **Copy the binary to the extcap folder**
 
-  ![wireshark about folders](../images/about_wireshark_folders.png)
+   Copy `fortigate-extcap.exe` (or the appropriate file for your platform) from the downloaded release into the extcap folder.
 
-3. Copy the binary to the extcap folder.
+   On Linux or macOS, make the binary executable: `chmod a+x fortigate-extcap`
 
-- Copy `fortigate-extcap.exe` (or the appropriate file for your platform) from the downloaded release into the "Personal Extcap Path" directory.
+4. **Restart Wireshark**
 
-- On Linux or macOS, make the plugin executable: `chmod a+x fortigate-extcap`
-
-4. Restart Wireshark
-
-- Restart Wireshark to load the custom Extcap extension.
+   Restart Wireshark to load the custom Extcap extension.
 
 ---
 
 ## Starting First Capture
 
-After successful installation, the extcap plugin should become visible as Fortigate Remote Capture. Click on the gear icon to configure the settings.
+After successful installation, the extcap plugin should become visible as **Fortigate Remote Capture** in Wireshark's capture interface list. Click the gear icon next to it to open the capture settings, then double-click the interface to start capturing.
 
 ![wireshark capture options](../images/wireshark_capture_options.png)
+
+See [Configuration](#configuration) for a description of all available settings.
 
 ---
 
@@ -82,17 +80,11 @@ After successful installation, the extcap plugin should become visible as Fortig
 | **Packet count** | Maximum number of packets to capture. Set to `0` for unlimited. |
 | **Capture Filter** | Capture filter in tcpdump syntax (e.g. `not port 443`). Leave empty to capture all traffic. The SSH management session is excluded automatically. |
 
-
-
 **Capture Interface:** Wireshark displays the FortiGate interface name for each packet (shown in the frame details under *Interface name*). It also records whether the traffic is inbound or outbound relative to the FortiGate.
 
 ![wireshark capture details](../images/capture_packet_interface.png)
 
-
-
 **Multi-VDOM:** The plugin automatically detects whether the FortiGate is running in multi-VDOM mode and enters the correct VDOM context before starting the capture. No manual configuration is needed.
-
-
 
 ### Authentication Tab
 
@@ -108,7 +100,6 @@ The plugin supports two authentication methods, tried in this order:
 1. **SSH agent**: if an SSH agent is running with a key loaded for the FortiGate, no password is needed. This is the recommended approach as no credentials appear on the command line.
 2. **Password**: plain SSH password entered in the field above.
 
-
 **Setting up SSH agent (Linux/macOS):**
 
 ```bash
@@ -118,8 +109,8 @@ ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
 ssh-add ~/.ssh/id_ed25519
 ```
 
-
 **Setting up SSH agent (Windows):**
+
 ```powershell
 # Run once as administrator
 Set-Service ssh-agent -StartupType Automatic
@@ -129,7 +120,6 @@ ssh-keygen -t ed25519 -f C:\Users\you\.ssh\id_ed25519
 # Add your key to the agent
 ssh-add C:\Users\you\.ssh\id_ed25519
 ```
-
 
 For SSH agent to work, the FortiGate user must have the corresponding public key configured. Copy the contents of your `.pub` file (e.g. `~/.ssh/id_ed25519.pub`) into the FortiGate config:
 ```
@@ -142,8 +132,7 @@ end
 
 **Note:** FortiGate requires a password to be set on every admin account, even when using SSH key authentication. Since this password will never be used for day-to-day access, set it to a long randomly generated string (32+ characters) and store it in a password manager.
 
-
-**SSH Host Key Verification**
+### SSH Host Key Verification
 
 The plugin verifies the FortiGate's SSH host key on every connection using the known_hosts file (default: `~/.ssh/known_hosts`).
 
@@ -155,8 +144,6 @@ To remove the old entry and allow a fresh key to be stored, either:
 - Or open `~/.ssh/known_hosts` in a text editor and delete the line that starts with the FortiGate's address or IP.
 
 After removal, the new key is stored automatically on the next connection.
-
-
 
 ### Debug Tab
 
@@ -199,19 +186,13 @@ Passwords are visible in the process list for the entire duration of the capture
 
 **Use a dedicated read-only admin account**
 
-Create a separate FortiGate admin account with only the access needed for packet capture, rather than using the `admin` account. This limits exposure if credentials are ever compromised.
+Create a separate FortiGate admin account with only the access needed for packet capture, rather than using the `admin` account. This limits exposure if credentials are ever compromised. See [How to create an admin user to do only packet capture](https://community.fortinet.com/fortigate-3/technical-tip-how-to-create-admin-user-to-do-only-packet-capture-187027) on the Fortinet community for step-by-step instructions.
+
+Once the account is created, assign your SSH public key to it:
 
 ```
-config system accprofile
-    edit "capture-only"
-        set sysgrp read
-        set netgrp read
-        set diaggrp read-write
-    next
-end
 config system admin
     edit "wireshark"
-        set accprofile "capture-only"
         set ssh-public-key1 "ssh-ed25519 AAAA..."
     next
 end
@@ -225,29 +206,36 @@ The plugin stores the FortiGate's SSH host key automatically on first connection
 
 ## Known Limitations
 
-- Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, which streams packets as a text hexdump over SSH rather than a binary protocol. Use a specific capture filter to focus on the traffic you need and avoid overloading the stream.
+Capture speed is limited by the FortiGate's `diagnose sniffer packet` command, which streams packets as a text hexdump over SSH rather than a binary protocol. Use a specific capture filter to focus on the traffic you need and avoid overloading the stream.
 
-
+---
 
 ## Troubleshooting
 
 **Wireshark shows no FortiGate extcap plugin after installing**
+
 - Make sure the binary is placed in the correct extcap folder: *Help → About Wireshark → Folders → Personal Extcap Path*
 - On Linux/macOS, make sure the binary is executable: `chmod +x fortigate-extcap`
 
 **Authentication failed**
+
 - Verify the username has CLI access on the FortiGate (not just web UI access).
 - If using SSH agent, confirm the agent is running (`ssh-add -l`) and the FortiGate user has the public key configured.
 - If using password, verify the password is correct.
+- If the error mentions a host key problem, see [Host key mismatch error](#troubleshooting) below.
 
 **Host key mismatch error**
+
 - The FortiGate's SSH host key has changed. This can happen after a replacement, re-image, or HA failover to a unit with a different host key. Remove the old entry with: `ssh-keygen -R <fortigate-address>`
 
 **Capture starts but no packets appear**
+
 - Your capture filter may be too restrictive, or the interface name is wrong. Try `any` as the interface and leave the capture filter empty.
 
 **Packets missing from capture**
+
 - FortiGate's NP offloading accelerates traffic through dedicated hardware processors, bypassing the software sniffer. To capture this traffic, temporarily disable NP offloading on the relevant firewall policy and re-enable it when done:
+
 ```
 config firewall policy
     edit <id>
@@ -284,7 +272,7 @@ end
 
 The plugin connects to the FortiGate over SSH and runs `diagnose sniffer packet <interface> '<filter>' 6`. The `6` is a verbosity level that makes the FortiGate output each captured packet as a timestamped text hexdump.
 
-The SSH management session is excluded automatically. The plugin determines its own local and remote IP addresses and prepends a `not (host … and host … and port …)` expression to any filter the user enters, so the capture traffic never includes the SSH connection itself.
+The SSH management session is excluded automatically. The plugin determines its own local and remote IP addresses and prepends a `not (host <localip> and host <remoteip> and port <dstport>)` expression to any filter the user enters, so the capture traffic never includes the SSH connection itself.
 
 The plugin reads the hexdump output in real time, extracts the raw packet bytes along with the interface name and traffic direction (inbound/outbound), and converts each packet into PCAPng format. Wireshark receives this as a standard live capture stream.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Already have Wireshark installed? Here's the short version:
 1. Download the binary for your platform from the [Releases](https://github.com/sanderzegers/fortigate-extcap/releases/) page.
 2. Copy it to your Wireshark extcap folder: open Wireshark, go to **Help → About Wireshark → Folders → Personal Extcap Path**, and click the location to open it.
 3. Linux/macOS only: make the binary executable: `chmod a+x fortigate-extcap`
-4. Restart Wireshark. The plugin appears as **Fortigate Remote Capture** in the capture interface list.
+4. Restart Wireshark. The plugin appears as **FortiGate Remote Capture** in the capture interface list.
 
 For first-time setup or more detail, see [Installation](#installation) below.
 
@@ -58,7 +58,7 @@ For first-time setup or more detail, see [Installation](#installation) below.
 
 ## Starting First Capture
 
-After successful installation, the extcap plugin should become visible as **Fortigate Remote Capture** in Wireshark's capture interface list.
+After successful installation, the extcap plugin should become visible as **FortiGate Remote Capture** in Wireshark's capture interface list.
 
 - **First use:** click the gear icon to open the capture settings, configure the FortiGate address and credentials, then click **Start** to begin capturing without leaving the dialog.
 - **Subsequent use:** double-clicking the interface skips the dialog and starts a capture immediately using the last saved settings.


### PR DESCRIPTION
## Summary

- Added Table of Contents, Quick Start, Security Recommendations, Capture Filter Examples, and How It Works sections to `docs/index.md`
- Expanded Authentication Tab with SSH agent setup instructions, SSH Host Key Verification behavior (including Windows known_hosts path), and a note that passwords are not saved to disk
- Promoted Troubleshooting entries to `###` headings for consistency and direct linking
- Simplified README installation to a 4-step quick start, clarified `fortidump` as the internal interface identifier, and noted `apt install` is Debian-based
- Standardized `Fortigate` → `FortiGate` throughout both files
- Removed outdated Windows Defender false positive section from README

## Test plan

- [x] Review `docs/index.md` rendering on GitHub for correct heading levels, anchor links, and table formatting
- [x] Verify all Table of Contents links resolve to the correct sections
- [x] Check that the ASCII diagram in How It Works renders correctly
- [x] Review README rendering on the repository front page

🤖 Generated with [Claude Code](https://claude.com/claude-code)